### PR TITLE
add a test for metadata on multiple keys

### DIFF
--- a/src/metadata.test.ts
+++ b/src/metadata.test.ts
@@ -32,3 +32,11 @@ test('with target and propery key', () => {
   decorator(target, propertyKey);
   expect(Reflect.hasOwnMetadata(metadataKey, target, propertyKey)).toBeTruthy();
 });
+
+test('with target and multiple properties', () => {
+  const target = {};
+  decorator(target, 'name1');
+  decorator(target, 'name2');
+  expect(Reflect.hasOwnMetadata(metadataKey, target, 'name1')).toBeTruthy();
+  expect(Reflect.hasOwnMetadata(metadataKey, target, 'name2')).toBeTruthy();
+});


### PR DESCRIPTION
Thank you for the wonderful library! I was looking for a smaller alternative to `reflect-metadata` and this project came up right on time.

However, there is an issue when you are trying to assign metadata to a multiple object keys. I have added a test that is supposed to pass, but fails with the current implementation.