### PR TITLE
fix: including the module breaks Reflect built-in

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -29,3 +29,70 @@ test('getOwnMetadata', () => {
   expect(Reflect.getOwnMetadata).toBeDefined();
   expect(Reflect.getOwnMetadata).toEqual(Reflection.getOwnMetadata);
 });
+
+// Test Reflect standard API
+
+test('apply', () => {
+  expect(Reflect.apply).toBeDefined();
+  expect(typeof Reflect.apply).toBe('function');
+});
+
+test('construct', () => {
+  expect(Reflect.construct).toBeDefined();
+  expect(typeof Reflect.construct).toBe('function');
+});
+
+test('defineProperty', () => {
+  expect(Reflect.defineProperty).toBeDefined();
+  expect(typeof Reflect.defineProperty).toBe('function');
+});
+
+test('deleteProperty', () => {
+  expect(Reflect.deleteProperty).toBeDefined();
+  expect(typeof Reflect.deleteProperty).toBe('function');
+});
+
+test('get', () => {
+  expect(Reflect.get).toBeDefined();
+  expect(typeof Reflect.get).toBe('function');
+});
+
+test('getOwnPropertyDescriptor', () => {
+  expect(Reflect.getOwnPropertyDescriptor).toBeDefined();
+  expect(typeof Reflect.getOwnPropertyDescriptor).toBe('function');
+});
+
+test('getPrototypeOf', () => {
+  expect(Reflect.getPrototypeOf).toBeDefined();
+  expect(typeof Reflect.getPrototypeOf).toBe('function');
+});
+
+test('has', () => {
+  expect(Reflect.has).toBeDefined();
+  expect(typeof Reflect.has).toBe('function');
+});
+
+test('isExtensible', () => {
+  expect(Reflect.isExtensible).toBeDefined();
+  expect(typeof Reflect.isExtensible).toBe('function');
+});
+
+test('ownKeys', () => {
+  expect(Reflect.ownKeys).toBeDefined();
+  expect(typeof Reflect.ownKeys).toBe('function');
+});
+
+test('preventExtensions', () => {
+  expect(Reflect.preventExtensions).toBeDefined();
+  expect(typeof Reflect.preventExtensions).toBe('function');
+});
+
+test('set', () => {
+  expect(Reflect.set).toBeDefined();
+  expect(typeof Reflect.set).toBe('function');
+});
+
+test('setPrototypeOf', () => {
+  expect(Reflect.setPrototypeOf).toBeDefined();
+  expect(typeof Reflect.setPrototypeOf).toBe('function');
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,8 +146,7 @@ export const Reflection = {
   metadata,
 };
 
-// TODO: Is this a good approach?
-(window as any).Reflect = Object.assign({}, Reflect, Reflection);
+Object.assign(Reflect, Reflection);
 
 declare global {
   namespace Reflect {


### PR DESCRIPTION
I added some additional tests to ensure the standard Reflect API. Without the suggested fix the tests fail. 

I tested the behavior of `Object.assign({}, Reflect)` in Firefox and Safari as well, and in both cases, it returns an empty object, so it appears not just to be an issue with Chrome.