### PR TITLE
Allow MetadataKey to be ES2015 Symbol

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export type MemberDecorator = <T>(
   propertyKey: PropertyKey,
   descriptor?: TypedPropertyDescriptor<T>,
 ) => TypedPropertyDescriptor<T> | void;
-export type MetadataKey = string;
+export type MetadataKey = string | symbol;
 export type PropertyKey = string | symbol;
 export type Target = object | Function;
 


### PR DESCRIPTION
This PR allows using Symbol as metadata property key.

The proposal itself also mentions it: https://rbuckton.github.io/reflect-metadata/#ordinary-object-internal-methods-and-internal-slots-defineownmetadata 

This is an important consideration especially for library maintainers to avoid potential naming collisions.