### PR TITLE
Add Reflect.hasMetadata to support InversifyJS 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist
 node_modules
 package-lock.json
+yarn.lock
+.idea

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Reflection does not currently cover the complete API surface of reflect-metadata
 Reflect.decorate(...);
 Reflect.defineMetadata(...);
 Reflect.getMetadata(...);
+Reflect.hasMetadata(...);
 Reflect.getOwnMetadata(...);
 Reflect.hasOwnMetadata(...);
 Reflect.metadata(...);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -25,6 +25,11 @@ test('hasOwnMetadata', () => {
   expect(Reflect.hasOwnMetadata).toEqual(Reflection.hasOwnMetadata);
 });
 
+test('hasMetadata', () => {
+  expect(Reflect.hasMetadata).toBeDefined();
+  expect(Reflect.hasMetadata).toEqual(Reflection.hasMetadata);
+});
+
 test('getOwnMetadata', () => {
   expect(Reflect.getOwnMetadata).toBeDefined();
   expect(Reflect.getOwnMetadata).toEqual(Reflection.getOwnMetadata);

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,10 @@ export function hasOwnMetadata(metadataKey: MetadataKey, target: Target, propert
   return !!ordinaryGetOwnMetadata(metadataKey, target, propertyKey);
 }
 
+export function hasMetadata(metadataKey: MetadataKey, target: Target, propertyKey?: PropertyKey): boolean {
+  return !!ordinaryGetMetadata(metadataKey, target, propertyKey);
+}
+
 function decorateConstructor(decorators: ClassDecorator[], target: Function): Function {
   decorators.reverse().forEach((decorator: ClassDecorator) => {
     const decorated = decorator(target);
@@ -142,6 +146,7 @@ export const Reflection = {
   defineMetadata,
   getMetadata,
   getOwnMetadata,
+  hasMetadata,
   hasOwnMetadata,
   metadata,
 };
@@ -155,6 +160,7 @@ declare global {
     let getMetadata: typeof Reflection.getMetadata;
     let getOwnMetadata: typeof Reflection.getOwnMetadata;
     let hasOwnMetadata: typeof Reflection.hasOwnMetadata;
+    let hasMetadata: typeof Reflection.hasMetadata;
     let metadata: typeof Reflection.metadata;
   }
 }


### PR DESCRIPTION
Note that there are no real tests for hasOwnMetadata as the tests for getOwnMetadata "cover" things. Likewise here. 