### PR TITLE
fix: package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,13 @@
   "name": "@abraham/reflection",
   "version": "0.10.0",
   "description": "Lightweight ES Module implementation of reflect-metadata",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.umd.js"
+    }
+  },
   "main": "./dist/index.umd.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Adds `type` and `exports` field in `package.json` for better support with node and typescript compiler, as well as modern dev tooling.

For my specific use case, without this `vite-node` does not handle this module properly. It ends up creating multiple instances of the module rather than a shared one.

