### PR TITLE
Fix ability to define falsy value

### DIFF
--- a/src/get-metadata.test.ts
+++ b/src/get-metadata.test.ts
@@ -40,3 +40,11 @@ test('when defined on prototype with a property key', () => {
   Reflect.defineMetadata('key', 'value', prototype, 'name');
   expect(Reflect.getMetadata('key', target, 'name')).toEqual('value');
 });
+
+test('when value is falsy', () => {
+  const target = {};
+  const value = 0;
+
+  Reflect.defineMetadata('key', value, target, 'name');
+  expect(Reflect.getMetadata('key', target, 'name')).toEqual(value);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,14 +125,14 @@ function ordinaryGetMetadata<MetadataValue>(
   target: Target,
   propertyKey?: PropertyKey,
 ): MetadataValue | undefined {
-  return ordinaryGetOwnMetadata<MetadataValue>(metadataKey, target, propertyKey)
+  return ordinaryGetOwnMetadata<MetadataValue>(metadataKey, target, propertyKey) !== undefined
     ? ordinaryGetOwnMetadata<MetadataValue>(metadataKey, target, propertyKey)
     : Object.getPrototypeOf(target)
       ? ordinaryGetMetadata(
-          metadataKey,
-          Object.getPrototypeOf(target),
-          propertyKey,
-        )
+        metadataKey,
+        Object.getPrototypeOf(target),
+        propertyKey,
+      )
       : undefined;
 }
 
@@ -175,7 +175,7 @@ export function hasOwnMetadata(
   target: Target,
   propertyKey?: PropertyKey,
 ): boolean {
-  return !!ordinaryGetOwnMetadata(metadataKey, target, propertyKey);
+  return ordinaryGetOwnMetadata(metadataKey, target, propertyKey) !== undefined;
 }
 
 export function hasMetadata(
@@ -183,7 +183,7 @@ export function hasMetadata(
   target: Target,
   propertyKey?: PropertyKey,
 ): boolean {
-  return !!ordinaryGetMetadata(metadataKey, target, propertyKey);
+  return ordinaryGetMetadata(metadataKey, target, propertyKey) !== undefined;
 }
 
 export function defineMetadata<MetadataValue>(


### PR DESCRIPTION
There is multiple places in the code where a truthy check is made against the metadata value to check if the metadata is defined.
It is problematic when the metadata value is a falsy value like number 0 or boolean false.
So I replaced those checks with explicit checks against undefined.
I don't see any case where it would not be the right thing to do.